### PR TITLE
Enable dynamic camera addition

### DIFF
--- a/frigate/api/app.py
+++ b/frigate/api/app.py
@@ -27,7 +27,7 @@ from frigate.api.auth import require_role
 from frigate.api.defs.query.app_query_parameters import AppTimelineHourlyQueryParameters
 from frigate.api.defs.request.app_body import AppConfigSetBody
 from frigate.api.defs.tags import Tags
-from frigate.config import FrigateConfig
+from frigate.config import FrigateConfig, CameraConfig
 from frigate.models import Event, Timeline
 from frigate.stats.prometheus import get_metrics, update_metrics
 from frigate.util.builtin import (
@@ -589,6 +589,31 @@ def restart():
         ),
         status_code=200,
     )
+
+
+@router.post("/cameras", dependencies=[Depends(require_role(["admin"]))])
+def add_camera(request: Request, body: dict = Body(...)):
+    """Dynamically add a camera configuration."""
+    try:
+        camera_config = CameraConfig(**body)
+    except ValidationError as e:
+        return JSONResponse(
+            content={"success": False, "message": str(e)},
+            status_code=400,
+        )
+
+    if camera_config.name in request.app.frigate_config.cameras:
+        return JSONResponse(
+            content={"success": False, "message": "Camera already exists"},
+            status_code=400,
+        )
+
+    request.app.frigate_config.cameras[camera_config.name] = camera_config
+
+    if getattr(request.app, "frigate_app", None) is not None:
+        request.app.frigate_app.add_camera(camera_config)
+
+    return JSONResponse(content={"success": True}, status_code=200)
 
 
 @router.get("/labels")

--- a/frigate/api/fastapi_app.py
+++ b/frigate/api/fastapi_app.py
@@ -57,6 +57,7 @@ def create_fastapi_app(
     onvif: OnvifController,
     stats_emitter: StatsEmitter,
     event_metadata_updater: EventMetadataPublisher,
+    frigate_app=None,
 ):
     logger.info("Starting FastAPI app")
     app = FastAPI(
@@ -127,6 +128,7 @@ def create_fastapi_app(
     app.onvif = onvif
     app.stats_emitter = stats_emitter
     app.event_metadata_updater = event_metadata_updater
+    app.frigate_app = frigate_app
     app.jwt_token = get_jwt_secret() if frigate_config.auth.enabled else None
 
     return app

--- a/frigate/app.py
+++ b/frigate/app.py
@@ -16,6 +16,7 @@ from playhouse.sqlite_ext import SqliteExtDatabase
 import frigate.util as util
 from frigate.api.auth import hash_password
 from frigate.api.fastapi_app import create_fastapi_app
+from frigate.config import CameraConfig
 from frigate.camera import CameraMetrics, PTZMetrics
 from frigate.comms.base_communicator import Communicator
 from frigate.comms.config_updater import ConfigPublisher
@@ -673,6 +674,7 @@ class FrigateApp:
                     self.onvif_controller,
                     self.stats_emitter,
                     self.event_metadata_updater,
+                    self,
                 ),
                 host="127.0.0.1",
                 port=5001,
@@ -768,3 +770,69 @@ class FrigateApp:
             shm.unlink()
 
         os._exit(os.EX_OK)
+
+    def add_camera(self, camera_config: CameraConfig) -> None:
+        """Dynamically add a camera and start associated processes."""
+        camera_config.create_ffmpeg_cmds()
+        name = camera_config.name
+
+        if not name:
+            logger.error("Camera config must include a name")
+            return
+
+        if name in self.config.cameras:
+            logger.error(f"Camera {name} already exists")
+            return
+
+        self.config.cameras[name] = camera_config
+
+        # initialize metrics and helpers
+        self.camera_metrics[name] = CameraMetrics()
+        self.ptz_metrics[name] = PTZMetrics(
+            autotracker_enabled=camera_config.onvif.autotracking.enabled
+        )
+        self.region_grids[name] = get_camera_regions_grid(
+            name,
+            camera_config.detect,
+            max(self.config.model.width, self.config.model.height),
+        )
+        self.detection_out_events[name] = mp.Event()
+
+        shm_frame_count = self.shm_frame_count()
+        for i in range(shm_frame_count):
+            frame_size = (
+                camera_config.frame_shape_yuv[0] * camera_config.frame_shape_yuv[1]
+            )
+            self.frame_manager.create(f"{name}_frame{i}", frame_size)
+
+        capture_process = util.Process(
+            target=capture_camera,
+            name=f"camera_capture:{name}",
+            args=(name, camera_config, shm_frame_count, self.camera_metrics[name]),
+        )
+        capture_process.daemon = True
+        self.camera_metrics[name].capture_process = capture_process
+        capture_process.start()
+
+        camera_process = util.Process(
+            target=track_camera,
+            name=f"camera_processor:{name}",
+            args=(
+                name,
+                camera_config,
+                self.config.model,
+                self.config.model.merged_labelmap,
+                self.detection_queue,
+                self.detection_out_events[name],
+                self.detected_frames_queue,
+                self.camera_metrics[name],
+                self.ptz_metrics[name],
+                self.region_grids[name],
+            ),
+            daemon=True,
+        )
+        self.camera_metrics[name].process = camera_process
+        camera_process.start()
+        logger.info(
+            f"Camera {name} added: capture {capture_process.pid}, processor {camera_process.pid}"
+        )


### PR DESCRIPTION
## Summary
- allow dynamic registration of a new camera
- expose an API endpoint to add cameras without restart
- pass FrigateApp instance to FastAPI app for runtime control

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68871aaaef28832897ddd19fedb76cad